### PR TITLE
Utilisation du logger de Bukkit.

### DIFF
--- a/app/src/main/java/info/projetcohesion/mcplugin/Plugin.java
+++ b/app/src/main/java/info/projetcohesion/mcplugin/Plugin.java
@@ -35,11 +35,11 @@ public class Plugin extends JavaPlugin {
             try {
                 Server.start();
             } catch (IOException e) {
-                System.err.println("Failed to boot the integrated HTTP server !");
+                this.getLogger().severe("Failed to boot the integrated HTTP server !");
                 e.printStackTrace();
             }
         } else {
-            System.err.println("ImageMagick is not working. Check your PATH for a working magick binary.");
+            this.getLogger().severe("ImageMagick is not working. Check your PATH for a working magick binary.");
         }
     }
 

--- a/app/src/main/java/info/projetcohesion/mcplugin/httpserver/Handler.java
+++ b/app/src/main/java/info/projetcohesion/mcplugin/httpserver/Handler.java
@@ -2,18 +2,22 @@ package info.projetcohesion.mcplugin.httpserver;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import info.projetcohesion.mcplugin.Plugin;
 import info.projetcohesion.mcplugin.commands.MapArtCommand;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 /**
  * The core of the integrated HTTP server.
  * The HTTP traffic is managed here.
  */
 public class Handler implements HttpHandler {
+    private final Logger logger = Plugin.getPlugin().getLogger();
+
     /**
      * Header used at the start of a file uploaded by a HTML form with <code>enctype="multipart/form-data"</code>
      */
@@ -37,7 +41,7 @@ public class Handler implements HttpHandler {
      */
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        System.out.println("HTTP request from " + exchange.getRemoteAddress().toString()); // Log the IPs addresses
+        logger.info("HTTP request from " + exchange.getRemoteAddress().toString()); // Log the IPs addresses
         if (exchange.getRequestMethod().equalsIgnoreCase("POST")) {
             byte[] data = exchange.getRequestBody().readAllBytes();
 
@@ -123,7 +127,7 @@ public class Handler implements HttpHandler {
      * @throws IOException If an I/O error occurs
      */
     private void badRequest(HttpExchange exchange) throws IOException {
-        System.err.println("Request from " + exchange.getRemoteAddress().toString() + " was malformed");
+        logger.warning("Request from " + exchange.getRemoteAddress().toString() + " was malformed");
         sendResponse(exchange, "Bad request", HttpCodes.BAD_REQUEST);
     }
 }

--- a/app/src/main/java/info/projetcohesion/mcplugin/httpserver/Server.java
+++ b/app/src/main/java/info/projetcohesion/mcplugin/httpserver/Server.java
@@ -1,12 +1,14 @@
 package info.projetcohesion.mcplugin.httpserver;
 
 import com.sun.net.httpserver.HttpServer;
+import info.projetcohesion.mcplugin.Plugin;
 import info.projetcohesion.mcplugin.utils.FileUtils;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.concurrent.Executors;
+import java.util.logging.Logger;
 
 /**
  * The integrated HTTP server
@@ -14,6 +16,7 @@ import java.util.concurrent.Executors;
 public class Server {
     private static HttpServer s_server;
     private static final FileUtils s_config = new FileUtils("http");
+    private static final Logger logger = Plugin.getPlugin().getLogger();
 
     /**
      * Start the integrated HTTP server
@@ -29,7 +32,7 @@ public class Server {
             s_server.setExecutor(Executors.newFixedThreadPool(s_config.get().getInt("perfs.threads")));
             s_server.start();
 
-            System.out.println("HTTP server started on " + s_server.getAddress().toString());
+            logger.info("HTTP server started on " + s_server.getAddress().toString());
         }
     }
 
@@ -41,7 +44,7 @@ public class Server {
         if(s_server != null) { // Don't stop an already stopped server
             s_server.stop(0); // Stop now
             s_server = null; // Stopped HttpServer objects can't be reused
-            System.out.println("HTTP server stopped");
+            logger.info("HTTP server stopped");
         }
     }
 
@@ -63,7 +66,7 @@ public class Server {
         } if (s_config.get().getConfigurationSection("perfs") == null) {
             s_config.get().set("perfs.threads", Runtime.getRuntime().availableProcessors());
 
-            System.out.println("Using all " + Runtime.getRuntime().availableProcessors() + " detected CPUs for HTTP traffic handling. You can change this in the config file.");
+            logger.info("Using all " + Runtime.getRuntime().availableProcessors() + " detected CPUs for HTTP traffic handling. You can change this in the config file.");
         }
 
         s_config.save();


### PR DESCRIPTION
Remplace toutes les utilisations de System.out et de System.err par l'instance de PluginLogger liée au plugin.