### PR TITLE
Fix réponse HTTP

### DIFF
--- a/app/src/main/java/info/projetcohesion/mcplugin/httpserver/handlers/FileHandler.java
+++ b/app/src/main/java/info/projetcohesion/mcplugin/httpserver/handlers/FileHandler.java
@@ -100,7 +100,7 @@ public class FileHandler implements HttpHandler {
 
             sendResponse(exchange, imageID, HttpCodes.MOVED_PERMANENTLY, _redirectUrl + "?id=" + imageID);
         } else {
-            sendResponse(exchange, "GET is not supported", HttpCodes.METHOD_NOT_ALLOWED);
+            sendResponse(exchange, exchange.getRequestMethod()+" is not supported (POST only)", HttpCodes.METHOD_NOT_ALLOWED);
         }
     }
 


### PR DESCRIPTION
Si une requête http n'est pas POST elle n'est pas forcément GET, elle 
peut par exemple aussi être UPDATE,DELETE,PUT...